### PR TITLE
Implement "smart command mode" of pdb++

### DIFF
--- a/ptpdb/__init__.py
+++ b/ptpdb/__init__.py
@@ -158,6 +158,15 @@ class PtPdb(pdb.Pdb):
                 if self.use_rawinput:
                     line = self._get_input()
 
+            # This implements "smart command mode"
+            # For single character variable names that are also commands,
+            # it will default to printing the variable.
+            if line and hasattr(self, 'do_' + line) and (
+                    line in self.curframe.f_globals or
+                    line in self.curframe.f_locals or
+                    line.startswith('=')):
+                line = '!' + line
+
             line = self.precmd(line)
             stop = self.onecmd(line)
             stop = self.postcmd(stop, line)


### PR DESCRIPTION
For single character variable names that are also commands, it will default to printing the variable.

E.g.: If I type "c" and <Enter> then it prints the value of the "c" variable (if there is one). If I want to continue instead, I can type "c" and press <tab> and it will complete to "cont" and then I can press <Enter>.

Fixes #4

Cc: @jonathanslenders, @RonnyPfannschmidt, @antocuni
