### PR TITLE
Add option to support IPython shell

### DIFF
--- a/ptpdb/layout.py
+++ b/ptpdb/layout.py
@@ -13,7 +13,8 @@ class PdbLeftMargin(TokenListControl):
     Show "(pdb)" when we have a pdb command or '>>>' when the user types a
     Python command.
     """
-    def __init__(self, settings, pdb_commands):
+    def __init__(self, settings, pdb_commands,
+                 ipython=False, prompt_manager=None):
         def get_tokens(cli):
             _, buffer = current_python_buffer(cli, settings)
 
@@ -24,6 +25,9 @@ class PdbLeftMargin(TokenListControl):
 
                 if any(c.startswith(command) for c in pdb_commands):
                     return [(Token.Prompt, '(pdb) ')]
+                elif ipython:
+                    text = prompt_manager.render('in', color=False, just=False)
+                    return [(Token.Layout.Prompt, text)]
                 else:
                     return [(Token.Prompt, '  >>> ')]
             else:


### PR DESCRIPTION
Do:

``` python
import ptpdb; ptpdb.set_trace(ipython=True)
```

and you get an IPython shell. My favorite part of this is that I can use the IPython `?` and `??` commands.

e.g.:

```
[marca@marca-mac2 smstack-test]$ python foo.py
[0] > /private/tmp/smstack-test/foo.py(5)<module>()
-> c = 7
(pdb) a
4
(pdb) n
[0] > /private/tmp/smstack-test/foo.py(6)<module>()
-> c = 8
In [1]: import subprocess
In [1]: subprocess.Popen?
Type:           type
String Form:    <class 'subprocess.Popen'>
File:           /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py
Docstring:      None
Constructor information:
 Definition:    subprocess.Popen(args, bufsize=0, executable=None, stdin=None, stdout=None, stderr=None, preexec_fn=None, close_fds=False, shell=False, cwd=None, env=None, universal_newlines=False, startupinfo=None, creationflags=0)
 Docstring:     Create new Popen instance.
```
